### PR TITLE
Assure it works with latest gfx-debug-draw

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -68,7 +68,6 @@ fn main() {
 
     let mut debug_renderer = DebugRenderer::from_canvas(
         &mut piston_window.canvas.borrow_mut(),
-        [win_width as u32, win_height as u32],
         64,
         None,
         None,
@@ -178,8 +177,6 @@ fn main() {
         menu.event(&e, &mut settings);
 
         e.resize(|width, height| {
-            debug_renderer.resize(width, height);
-
             // Update projection matrix
             projection = CameraPerspective {
                 fov: 90.0f32,


### PR DESCRIPTION
- The `from_canvas()` function changed signature
- `resize()` was removed from window. It seems to handle this correctly anyway though

gfx-debug-draw I used was [this one](https://github.com/PistonDevelopers/gfx-debug-draw#5e8f03faeff604582a4be09391ee64e52e85bef3).
